### PR TITLE
feat: Add configurable base image support in build script

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -69,7 +69,7 @@ jobs:
             type=raw,value=${{ matrix.jekyll-version }}-{{date 'YYYYMMDDTHHmm'}}
             type=raw,value=${{ matrix.jekyll-version }}
           flavor: |
-            latest=${{ matrix.jekyll-version == '4.2.1' }}
+            latest=${{ matrix.jekyll-version == '4.2.2' }}
             prefix=
             suffix=
 
@@ -85,6 +85,7 @@ jobs:
           cache-from: type=local,src=${{ runner.temp }}/.buildx-cache
           cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new,mode=max
           build-args: |
+            BASE_IMAGE='ruby:3.4.2-alpine3.21'
             JEKYLL_VERSION=${{ matrix.jekyll-version }}
             JEKYLL_DOCKER_TAG=${{ matrix.jekyll-version }}
             RUBYOPT='-W0'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ruby:3.4.2-alpine3.21
+ARG BASE_IMAGE=ruby:3.4.2-alpine3.21
+FROM ${BASE_IMAGE}
 LABEL maintainer="Tiryoh <tiryoh@gmail.com>"
 COPY rootfs /
 

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ DOCKER_HUB_USER="tiryoh"
 DOCKER_TAG_BASE="jekyll"
 DOCKER_TAG="${DOCKER_TAG_BASE}:${JEKYLL_VERSION}"
 RUBYOPT="-W0"
-BASE_IMAGE="ruby:3.4.2-alpine3.21"
+BASE_IMAGE=${BASE_IMAGE:-"ruby:3.4.2-alpine3.21"}
 
 if git rev-parse --verify HEAD > /dev/null 2>&1 ; then
     COMMIT_HASH="$(git rev-parse --verify HEAD)"

--- a/build.sh
+++ b/build.sh
@@ -4,8 +4,9 @@ set -eu
 JEKYLL_VERSION=${JEKYLL_VERSION:-4.2.0}
 DOCKER_HUB_USER="tiryoh"
 DOCKER_TAG_BASE="jekyll"
-DOCKER_TAG="$DOCKER_TAG_BASE:$JEKYLL_VERSION"
+DOCKER_TAG="${DOCKER_TAG_BASE}:${JEKYLL_VERSION}"
 RUBYOPT="-W0"
+BASE_IMAGE="ruby:3.4.2-alpine3.21"
 
 if git rev-parse --verify HEAD > /dev/null 2>&1 ; then
     COMMIT_HASH="$(git rev-parse --verify HEAD)"
@@ -13,10 +14,11 @@ else
     COMMIT_HASH="null"
 fi
 
-docker build -t $DOCKER_HUB_USER/$DOCKER_TAG \
- --build-arg RUBYOPT=$RUBYOPT \
- --build-arg JEKYLL_DOCKER_TAG=$JEKYLL_VERSION \
- --build-arg JEKYLL_VERSION=$JEKYLL_VERSION \
- --build-arg JEKYLL_DOCKER_COMMIT=$COMMIT_HASH \
- --build-arg JEKYLL_DOCKER_NAME=$DOCKER_TAG_BASE \
+docker build -t "${DOCKER_HUB_USER}/${DOCKER_TAG}" \
+ --build-arg BASE_IMAGE="${BASE_IMAGE}" \
+ --build-arg RUBYOPT="${RUBYOPT}" \
+ --build-arg JEKYLL_DOCKER_TAG="${JEKYLL_VERSION}" \
+ --build-arg JEKYLL_VERSION="${JEKYLL_VERSION}" \
+ --build-arg JEKYLL_DOCKER_COMMIT="${COMMIT_HASH}" \
+ --build-arg JEKYLL_DOCKER_NAME="${DOCKER_TAG_BASE}" \
  -f Dockerfile .


### PR DESCRIPTION
- Modify Dockerfile to accept BASE_IMAGE as an ARG
- Update build.sh to pass BASE_IMAGE build argument
- Use string interpolation for more consistent variable handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced the container build process flexibility by allowing users to override the default base image, enabling greater customization during builds.
  - Updated build scripts for improved consistency in variable usage, contributing to a more robust and predictable build workflow.
  - Adjusted deployment workflow to reflect the latest version check for deployment purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->